### PR TITLE
pip+sendgrid-django (before django-anymail is configured)

### DIFF
--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -18,6 +18,7 @@ Collectfast==0.5.2
 # Email backends for Mailgun, Postmark, SendGrid and more
 # -------------------------------------------------------
 django-anymail==0.11
+sendgrid-django==4.0.4
 
 # Raven is the Sentry client
 # --------------------------


### PR DESCRIPTION
Add sendgrid, before the django-anymail is configured.